### PR TITLE
update modules/nested_lab/main.tf to use wait_for_guest_net_routable

### DIFF
--- a/modules/nested_lab/main.tf
+++ b/modules/nested_lab/main.tf
@@ -59,7 +59,8 @@ resource "vsphere_virtual_machine" "vm" {
   num_cpus = 2
   memory   = 6144
 
-  wait_for_guest_net_timeout = 0
+  wait_for_guest_net_timeout = 5
+  wait_for_guest_net_routable = false
 
   network_interface {
     network_id = "${data.vsphere_network.network.id}"


### PR DESCRIPTION
# Pull Request

## Description

This PR updates modules/nested_lab/main.tf to use the wait_for_guest_net_routable feature introduced in version 1.4.1 of the vsphere provider.

## Related Issue

This project only accepts pull requests related to open issues.

* If suggesting a new feature or change, please discuss it in an issue first.
* If fixing a bug, there should be an issue describing it with steps to reproduce

https://github.com/vmug-labs/vmug-labs/issues/1

## Motivation and Context

Why is this change required? What problem does it solve?
Waiting for the IP address on the nested ESXi vm to be properly applied ensure it is available for additional configuration by terraform.

## Testing Procedure

* Please describe in detail how you tested your changes.
* Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, et cetera.

## Screenshots (optional)

Please insert screenshots here.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

* [ ] Bug fix (non-breaking change which fixes an issue).
* [x] New feature (non-breaking change which adds functionality).
* [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask.  We're here to help!

* [ ] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have read the **[CONTRIBUTION](https://github.com/vmug-labs/vmug-labs/blob/master/.github/CONTRIBUTING.md)** document.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
